### PR TITLE
rex module to run sparrow disk check

### DIFF
--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -18,7 +18,6 @@ task prepare => sub {
       install package => $pkg;
    }
 
-   
    my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
    say $output;
 
@@ -66,6 +65,7 @@ task configure => sub {
 task run => sub {
 
    my $output = run "sparrow check run system disk";
+
    my $status = $?;
    say $output;
 
@@ -79,7 +79,7 @@ task run => sub {
 
 =head1 NAME
 
-Rex::Misc::Sparrow::DiskCheck - elementary file system checks using df utility report 
+Rex::Misc::Sparrow::DiskCheck - elementary file system checks using df utility report. 
 
 =head1 DESCRIPTION
 
@@ -111,7 +111,7 @@ Installs sparrow plugin
 
 =item configure
 
-Configure test suite. Use threshold to set minimum availbale disk space to allow in percentage
+Configure test suite. Use threshold to set minimum available disk space to allow in percentage
 
    rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:configure --threshold=80
 

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -5,71 +5,71 @@ use Rex::Misc::ShellBlock;
 
 task prepare => sub {
 
-   my ( $params ) = @_;
+  my ( $params ) = @_;
 
-   my $pkg_list = case operating_system, {
-      Centos  => [ "perl-Data-Dumper", "perl-devel" ],
-      default => [ ],
-   };
+  my $pkg_list = case operating_system, {
+     Centos  => [ "perl-Data-Dumper", "perl-devel" ],
+     default => [ ],
+  };
 
-   install package => 'curl';
+  install package => 'curl';
 
-   for my $pkg (@{$pkg_list}) {
-      install package => $pkg;
-   }
+  for my $pkg (@{$pkg_list}) {
+     install package => $pkg;
+  }
 
-   my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
-   say $output;
+  my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
+  say $output;
 
-   my $output = run "cpanm Test::More Sparrow";
-   say $output;
-  
+  my $output = run "cpanm Test::More Sparrow";
+  say $output;
+
 };
 
 task setup => sub {
 
-   my ( $params ) = @_;
+  my ( $params ) = @_;
 
-   my $output = run "sparrow index update && sparrow plg install df-check";  
+  my $output = run "sparrow index update && sparrow plg install df-check";  
 
-   say $output;
+  say $output;
 
 };
 
 task configure => sub {
 
-   my ( $params ) = @_;
+  my ( $params ) = @_;
 
-   file "/tmp/sparrow-df-check.ini",
-      content   => template("files/suite.ini", threshold => $params->{threshold} || 80 ),
-   ;
+  file "/tmp/sparrow-df-check.ini",
+     content   => template("files/suite.ini", threshold => $params->{threshold} || 80 ),
+  ;
 
-   my $output = run "sparrow project create system";  
-   say $output;
+  my $output = run "sparrow project create system";  
+  say $output;
 
-   my $output = run "sparrow check add system disk";  
-   say $output;
+  my $output = run "sparrow check add system disk";  
+  say $output;
 
-   my $output = run "sparrow check set system disk df-check";  
-   say $output;
+  my $output = run "sparrow check set system disk df-check";  
+  say $output;
 
-   my $output = run "sparrow check load_ini system disk /tmp/sparrow-df-check.ini";  
-   say $output;
+  my $output = run "sparrow check load_ini system disk /tmp/sparrow-df-check.ini";  
+  say $output;
 
-   my $output = run "sparrow check show system disk";  
-   say $output;
+  my $output = run "sparrow check show system disk";  
 
+  say $output;
 
 };
 
 task run => sub {
 
-   my $output = run "sparrow check run system disk";
+  my $output = run "sparrow check run system disk";
 
-   my $status = $?;
-   say $output;
+  my $status = $?;
+  say $output;
 
-   die "sparrow check run system disk returned bad exit code" unless  $status == 0;
+  die "sparrow check run system disk returned bad exit code" unless  $status == 0;
 
 };
 
@@ -89,15 +89,15 @@ Checks available disk spaces parsing `df -h` output
 
 To execute check:
 
-   $ cat Rexfile 
+  $ cat Rexfile 
 
-   use Rex -feature => ['1.3'];
+  use Rex -feature => ['1.3'];
 
-   require Rex::Misc::Sparrow::DiskCheck;
+  require Rex::Misc::Sparrow::DiskCheck;
 
-   1;
+  1;
 
-   $ rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:run
+  $ rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:run
 
 =head1 TASKS
 
@@ -113,7 +113,7 @@ Installs sparrow plugin
 
 Configure test suite. Use threshold to set minimum available disk space to allow in percentage
 
-   rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:configure --threshold=80
+  rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:configure --threshold=80
 
 =back
 

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -15,7 +15,7 @@ sub prepare {
   install package => 'curl';
 
   for my $pkg (@{$pkg_list}) {
-     install package => $pkg;
+     pkg $pkg, ensure => 'installed';
   }
 
   my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
@@ -66,7 +66,7 @@ task configure => sub {
 
 task run => sub {
 
-  my $output = run "sparrow check run system disk";
+  my $output = run "sparrow check run system disk 2>&1";
 
   my $status = $?;
   say $output;

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -66,12 +66,6 @@ Installs sparrow plugin
 
 =cut
 
-=head1 Advanced settings
-
-All the tasks are accepted --proxy parameter for the hosts with http trafic under http proxy:
-
-   rex Misc:Sparrow:DiskCheck:prepare --proxy=http://foo.bar.baz
-
 =head1 See Also
 
 https://sparrowhub.org/info/df-check

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -79,7 +79,7 @@ task run => sub {
 
 =head1 NAME
 
-Rex::Misc::Sparrow::DiskCheck - elementary file system checks using df utility report. 
+Rex::Misc::Sparrow::DiskCheck - elementary file system checks using df utility report
 
 =head1 DESCRIPTION
 
@@ -122,4 +122,3 @@ Configure test suite. Use threshold to set minimum available disk space to allow
 =head1 See Also
 
 https://sparrowhub.org/info/df-check
-

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -34,7 +34,7 @@ task configure => sub {
    my ( $params ) = @_;
 
    file "/tmp/sparrow-df-check.ini",
-      content   => template("files/etc/ntp.conf", threshold => $params->{threshold} || 80 ),
+      content   => template("files/suite.ini", threshold => $params->{threshold} || 80 ),
    ;
 
    my $output = run "sparrow project create system";  
@@ -56,8 +56,13 @@ task configure => sub {
 };
 
 task run => sub {
-   my $output = run "sparrow plg run df-check";
+
+   my $output = run "sparrow check run system disk";
+   my $status = $?;
    say $output;
+
+   die "sparrow check run system disk returned bad exit code" unless  $status == 0;
+
 };
 
 1;
@@ -89,6 +94,14 @@ To execute check:
 =item setup
 
 Installs sparrow plugin
+
+=over 4
+
+=item configure
+
+Configure test suite. Use threshold to set minimum availbale disk space to allow in percentage
+
+   rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:configure --threshold=80
 
 =back
 

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -1,0 +1,66 @@
+package Rex::Misc::Sparrow::DiskCheck;
+
+use Rex -base;
+use Rex::Misc::ShellBlock;
+
+task prepare => sub {
+
+   my ( $params ) = @_;
+
+   my $proxy_export = $params->{proxy} ? 
+   "export http_proxy=$params->{proxy}; export https_proxy=$params->{proxy};" : "";
+
+   install package => 'curl';
+
+   my $output = run "$proxy_export curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
+   say $output;
+
+   my $output = run "$proxy_export cpanm Sparrow";
+   say $output;
+  
+
+};
+
+task setup => sub {
+   my $output = run "hostname -f";
+   say $output;
+};
+
+#task setup => sub {
+#   my $output = run "hostname -f";
+#   say $output;
+#};
+
+1;
+
+=pod
+
+=head1 NAME
+
+$::module_name - {{ SHORT DESCRIPTION }}
+
+=head1 DESCRIPTION
+
+{{ LONG DESCRIPTION }}
+
+=head1 USAGE
+
+{{ USAGE DESCRIPTION }}
+
+ include qw/Rex::Misc::Sparrow::DiskCheck/;
+
+ task yourtask => sub {
+    Rex::Misc::Sparrow::DiskCheck::example();
+ };
+
+=head1 TASKS
+
+=over 4
+
+=item example
+
+This is an example Task. This task just output's the uptime of the system.
+
+=back
+
+=cut

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -9,9 +9,9 @@ task prepare => sub {
 
    my $proxy_export = $params->{proxy} ? 
    "export http_proxy=$params->{proxy}; export https_proxy=$params->{proxy};" : "";
-
+   
    install package => 'curl';
-
+   
    my $output = run "$proxy_export curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
    say $output;
 
@@ -22,8 +22,15 @@ task prepare => sub {
 };
 
 task setup => sub {
-   my $output = run "hostname -f";
+
+   my ( $params ) = @_;
+
+   my $proxy_export = $params->{proxy} ? 
+   "export http_proxy=$params->{proxy}; export https_proxy=$params->{proxy};" : "";
+
+   my $output = run "$proxy_export export PATH=/usr/local/bin/PATH:\$PATH; sparrow index update && sparrow install df-check";  
    say $output;
+
 };
 
 #task setup => sub {
@@ -37,30 +44,41 @@ task setup => sub {
 
 =head1 NAME
 
-$::module_name - {{ SHORT DESCRIPTION }}
+Rex::Misc::Sparrow::DiskCheck - elementary file system checks using df utility report 
 
 =head1 DESCRIPTION
 
-{{ LONG DESCRIPTION }}
+Checks available disk spaces parsing `df -h` output
 
 =head1 USAGE
 
-{{ USAGE DESCRIPTION }}
+To execute check:
 
  include qw/Rex::Misc::Sparrow::DiskCheck/;
 
- task yourtask => sub {
-    Rex::Misc::Sparrow::DiskCheck::example();
+ task run => sub {
+    Rex::Misc::Sparrow::DiskCheck::run();
  };
 
 =head1 TASKS
 
 =over 4
 
-=item example
+=item setup
 
-This is an example Task. This task just output's the uptime of the system.
+Installs sparrow plugin
 
 =back
 
 =cut
+
+=head1 Advanced settings
+
+All the tasks are accepted --proxy parameter for the hosts with http trafic under http proxy:
+
+   rex Misc:Sparrow:DiskCheck:prepare --proxy=http://foo.bar.baz
+
+=head1 See Also
+
+https://sparrowhub.org/info/df-check
+

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -7,15 +7,12 @@ task prepare => sub {
 
    my ( $params ) = @_;
 
-   my $proxy_export = $params->{proxy} ? 
-   "export http_proxy=$params->{proxy}; export https_proxy=$params->{proxy};" : "";
-   
    install package => 'curl';
    
-   my $output = run "$proxy_export curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
+   my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
    say $output;
 
-   my $output = run "$proxy_export cpanm Sparrow";
+   my $output = run "cpanm Sparrow";
    say $output;
   
 
@@ -25,10 +22,7 @@ task setup => sub {
 
    my ( $params ) = @_;
 
-   my $proxy_export = $params->{proxy} ? 
-   "export http_proxy=$params->{proxy}; export https_proxy=$params->{proxy};" : "";
-
-   my $output = run "$proxy_export export PATH=/usr/local/bin/PATH:\$PATH; sparrow index update && sparrow install df-check";  
+   my $output = run "export PATH=/usr/local/bin/PATH:\$PATH; sparrow index update && sparrow install df-check";  
    say $output;
 
 };

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -8,11 +8,12 @@ task prepare => sub {
    my ( $params ) = @_;
 
    install package => 'curl';
+   install package => 'perl-devel';
    
    my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
    say $output;
 
-   my $output = run "cpanm Sparrow";
+   my $output = run "cpanm Test::More Sparrow";
    say $output;
   
 
@@ -22,15 +23,42 @@ task setup => sub {
 
    my ( $params ) = @_;
 
-   my $output = run "export PATH=/usr/local/bin/PATH:\$PATH; sparrow index update && sparrow install df-check";  
+   my $output = run "sparrow index update && sparrow plg install df-check";  
+
    say $output;
 
 };
 
-#task setup => sub {
-#   my $output = run "hostname -f";
-#   say $output;
-#};
+task configure => sub {
+
+   my ( $params ) = @_;
+
+   file "/tmp/sparrow-df-check.ini",
+      content   => template("files/etc/ntp.conf", threshold => $params->{threshold} || 80 ),
+   ;
+
+   my $output = run "sparrow project create system";  
+   say $output;
+
+   my $output = run "sparrow check add system disk";  
+   say $output;
+
+   my $output = run "sparrow check set system disk df-check";  
+   say $output;
+
+   my $output = run "sparrow check load_ini system disk /tmp/sparrow-df-check.ini";  
+   say $output;
+
+   my $output = run "sparrow check show system disk";  
+   say $output;
+
+
+};
+
+task run => sub {
+   my $output = run "sparrow plg run df-check";
+   say $output;
+};
 
 1;
 

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -21,7 +21,7 @@ sub prepare {
   my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
   say $output;
 
-  my $output = run "cpanm Test::More Sparrow";
+  my $output = run "cpanm Digest::MD5 Test::More Sparrow";
   say $output;
 
 };

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -7,8 +7,17 @@ task prepare => sub {
 
    my ( $params ) = @_;
 
+   my $pkg_list = case operating_system, {
+      Centos  => [ "perl-Data-Dumper", "perl-devel" ],
+      default => [ ],
+   };
+
    install package => 'curl';
-   install package => 'perl-devel';
+
+   for my $pkg (@{$pkg_list}) {
+      install package => $pkg;
+   }
+
    
    my $output = run "curl -fkL http://cpanmin.us/ -o /bin/cpanm && chmod +x /bin/cpanm";  
    say $output;
@@ -16,7 +25,6 @@ task prepare => sub {
    my $output = run "cpanm Test::More Sparrow";
    say $output;
   
-
 };
 
 task setup => sub {

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -3,12 +3,12 @@ package Rex::Misc::Sparrow::DiskCheck;
 use Rex -base;
 use Rex::Misc::ShellBlock;
 
-task prepare => sub {
+sub prepare {
 
   my ( $params ) = @_;
 
   my $pkg_list = case operating_system, {
-     Centos  => [ "perl-Data-Dumper", "perl-devel" ],
+     CentOS  => [ "perl-devel", "perl-Data-Dumper" ],
      default => [ ],
   };
 
@@ -29,6 +29,8 @@ task prepare => sub {
 task setup => sub {
 
   my ( $params ) = @_;
+
+  prepare();
 
   my $output = run "sparrow index update && sparrow plg install df-check";  
 

--- a/Rex/Misc/Sparrow/DiskCheck/__module__.pm
+++ b/Rex/Misc/Sparrow/DiskCheck/__module__.pm
@@ -81,11 +81,15 @@ Checks available disk spaces parsing `df -h` output
 
 To execute check:
 
- include qw/Rex::Misc::Sparrow::DiskCheck/;
+   $ cat Rexfile 
 
- task run => sub {
-    Rex::Misc::Sparrow::DiskCheck::run();
- };
+   use Rex -feature => ['1.3'];
+
+   require Rex::Misc::Sparrow::DiskCheck;
+
+   1;
+
+   $ rex -H 127.0.0.1:2222 -u root -p 123 Misc:Sparrow:DiskCheck:run
 
 =head1 TASKS
 

--- a/Rex/Misc/Sparrow/DiskCheck/files/suite.ini
+++ b/Rex/Misc/Sparrow/DiskCheck/files/suite.ini
@@ -1,0 +1,3 @@
+[disk]
+# disk used threshold in %
+threshold = 10

--- a/Rex/Misc/Sparrow/DiskCheck/files/suite.ini
+++ b/Rex/Misc/Sparrow/DiskCheck/files/suite.ini
@@ -1,3 +1,3 @@
 [disk]
 # disk used threshold in %
-threshold = 10
+threshold = <%= $threshold %>

--- a/Rex/Misc/Sparrow/DiskCheck/meta.yml
+++ b/Rex/Misc/Sparrow/DiskCheck/meta.yml
@@ -1,0 +1,4 @@
+Name: Rex::Misc::Sparrow::DiskCheck
+Description: elementary file system checks using df utility report
+Author: Alexey Melezhik <melezhik@gmail.com> 
+License: Apache 2.0


### PR DESCRIPTION
Hi @ferki ! According to our latest talk in irc, this is very first try. The code may look quite raw but to examine how it looks like I am creating a PR. My thoughts:
- Probably it is better to move cpanm installation part  into dedicated rex module, I found http://modules.rexify.org/module/Rex::Lang::Perl::Cpanm , may be it is better to rely on it, but my fears are code is quite old. Anyway right now installing cpanm now rae just few lines of code, so have it here in place.
- I have tested only on Centos7, other distros need to be tested 
- Not sure if I need have a distinct prepare task, it would probably better just move prepare code into setup task? Please give me an advice ...

That's it ... :smile: 

PS link to sparrow plugin  - https://sparrowhub.org/info/df-check 
