### PR TITLE
New way integration Rex and Sparrow

### DIFF
--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -88,20 +88,20 @@ task 'configure', sub {
 Runs sparrow plguin(s) (with parameters).
 
  $ rex -qw Misc:Sparrow:plugin_run # run all plugins
- $ rex -qw Misc:Sparrow:plugin_run # run all plugins
- $ rex -qw Misc:Sparrow:plugin_run --plugin=df-check --threshold=70 # run df-check plugin with parameter
+ $ rex -qw Misc:Sparrow:plugin_run --plugin=df-check  # run df-check plugin only
+ $ rex -qw Misc:Sparrow:plugin_run --plugin=df-check --threshold=88 # run df-check plugin with parameter
 
 =cut
 
 desc 'Runs sparrow plugins';
-task 'check', sub {
+task 'plugin_run', sub {
   my $params = shift;
   foreach my $plg ( grep { my $name = $_; $params->{plugin}? ( $name eq $params->{plugin}  ) : 1 } @{ $sparrow->{plugins} } ) {
     my $plg_params =  $params || {};
-    delete @{$plg_params}{qw{name}};
+    delete @{$plg_params}{qw{plugin}};
     my $plg_params_string;
-    for my $n (%{$plg_params}){
-      $plg_params_string.=" --param $n=".($plg_params->{name});
+    for my $n (keys %{$plg_params}){
+      $plg_params_string.=" --param $n=".($plg_params->{$n});
     }
     say scalar run "sparrow plg run $plg $plg_params_string";
   }

--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -101,7 +101,11 @@ task 'plugin_run', sub {
     delete @{$plg_params}{qw{plugin Misc:Sparrow:plugin_run}};
     my $plg_params_string = '';
     for my $n (keys %{$plg_params}){
-      $plg_params_string.=" --param $n=".($plg_params->{$n});
+      if ($plg_params->{$n}=~/\s/){
+        $plg_params_string.=" --param $n=\"'".($plg_params->{$n})."'\""
+      }else{
+        $plg_params_string.=" --param $n=".($plg_params->{$n})
+      }
     }
     say scalar run "sparrow plg run $plg $plg_params_string";
   }

--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -66,7 +66,7 @@ Installs sparrow plugin via cpanm.
 desc 'Setup sparrow';
 task 'setup', sub {
   cpanm -install;
-  cpanm -install => [qw(Digest::MD5 Test::More Sparrow~0.1.2)];
+  cpanm -install => [qw(Digest::MD5 Test::More Sparrow~0.1.3)];
 };
 
 =item configure

--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -30,11 +30,11 @@ our $sparrow_temp = File::Spec->tmpdir();
 
 =head1 NAME
 
-Rex::Misc::Sparrow - manage and run sparrow checks
+Rex::Misc::Sparrow - manage and run sparrow plugins
 
 =head1 DESCRIPTION
 
-Setup sparrow and its checks described in the configuration file, and run them.
+Setup sparrow and its plugins described in the configuration file, and run them.
 
 =head1 USAGE
 
@@ -49,111 +49,53 @@ Create configuration either as C<files/sparrow.yml> or in CMDB. See C<files/spar
 
 =item setup
 
-Installs sparrow plugin via cpanm, and configures checks.
+Installs sparrow plugin via cpanm.
 
 =cut
 
 desc 'Setup sparrow';
 task 'setup', sub {
   cpanm -install;
-  cpanm -install => [qw(Digest::MD5 Test::More Sparrow~0.0.21)];
-
-  needs 'configure';
+  cpanm -install => [qw(Digest::MD5 Test::More Sparrow~0.1.2)];
 };
 
 =item configure
 
-Installs and configures sparrow checks as described in either CMDB or in C<files/sparrow.yml>.
+Installs sparrow plguins as described in either CMDB or in C<files/sparrow.yml>.
 
 =cut
 
-desc 'Configure sparrow checks';
+desc 'Configure sparrow plugins';
 task 'configure', sub {
   run 'sparrow index update';
-
-  foreach my $project ( keys %{$sparrow} ) {
-    run "sparrow project create $project";
-
-    foreach my $check ( @{ $sparrow->{$project} } ) {
-      run "sparrow plg install $check->{plugin}";
-      run "sparrow check add $project $check->{checkname}";
-      run "sparrow check set $project $check->{checkname} $check->{plugin}";
-      configure_check( $project, $check );
-    }
+  foreach my $plg ( @{ $sparrow->{plugins} } ) {
+    run "sparrow plg install $plg";
   }
 };
 
-=item check
+=item plugin_run
 
-Runs configured sparrow checks.
+Runs sparrow plguin(s) (with parameters).
 
- $ rex -qw Misc:Sparrow:check
+ $ rex -qw Misc:Sparrow:plugin_run # run all plugins
+ $ rex -qw Misc:Sparrow:plugin_run # run all plugins
+ $ rex -qw Misc:Sparrow:plugin_run --plugin=df-check --threshold=70 # run df-check plugin with parameter
 
 =cut
 
-desc 'Runs sparrow checks';
+desc 'Runs sparrow plugins';
 task 'check', sub {
-  foreach my $project ( keys %{$sparrow} ) {
-    foreach my $check ( @{ $sparrow->{$project} } ) {
-      say scalar run "sparrow check run $project $check->{checkname}";
+  my $params = shift;
+  foreach my $plg ( grep { my $name = $_; $params->{plugin}? ( $name eq $params->{plugin}  ) : 1 } @{ $sparrow->{plugins} } ) {
+    my $plg_params =  $params || {};
+    delete @{$plg_params}{qw{name}};
+    my $plg_params_string;
+    for my $n (%{$plg_params}){
+      $plg_params_string.=" --param $n=".($plg_params->{name});
     }
+    say scalar run "sparrow plg run $plg $plg_params_string";
   }
 };
-
-=item dump_config
-
-Dumps sparrow configuration
-
-=cut
-
-desc 'Dumps sparrow configuration';
-task 'dump_config', sub {
-  foreach my $project ( keys %{$sparrow} ) {
-    foreach my $check ( @{ $sparrow->{$project} } ) {
-      say scalar run "sparrow check show $project $check->{checkname}";
-    }
-  }
-};
-
-=back
-
-=head1 SUBROUTINES
-
-=over 4
-
-=item configure_check( $project, $check )
-
-Configure a sparrow check. C<$check> is the full data structure from CMDB or  C<sparrow.yml>.
-
-=cut
-
-sub configure_check {
-  my ( $project, $check ) = @_;
-
-  my $config_file = my $default_config =
-    File::Spec->join( '~', 'sparrow', 'plugins', 'public', $check->{plugin},
-    'suite.ini' );
-  my $temp_config;
-
-  if ( exists $check->{settings} ) {
-    $temp_config =
-      File::Spec->join( $sparrow_temp,
-      'sparrow-' . $check->{checkname} . '.ini' );
-
-    cp $default_config, $temp_config;
-    chmod 700, $temp_config;
-
-    while ( my ( $key, $value ) = each %{ $check->{settings} } ) {
-      sed qr{\b$key\b = .*}, join( ' = ', $key, $value ), $temp_config;
-    }
-
-    $config_file = $temp_config;
-  }
-
-  run "sparrow check load_ini $project $check->{checkname} $config_file";
-
-  file $temp_config, ensure => 'absent';
-}
 
 =back
 

--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -43,6 +43,16 @@ Create configuration either as C<files/sparrow.yml> or in CMDB. See C<files/spar
  $ rexify --use=Rex::Misc::Sparrow
  $ rex Misc:Sparrow:setup
 
+Example configuration.
+
+ $ cat sparrow.yml
+
+  sparrow:
+    plugins:
+      - df-check
+      - nginx-check
+      - perlbrew
+  
 =head1 TASKS
 
 =over 4

--- a/Rex/Misc/Sparrow/__module__.pm
+++ b/Rex/Misc/Sparrow/__module__.pm
@@ -98,8 +98,8 @@ task 'plugin_run', sub {
   my $params = shift;
   foreach my $plg ( grep { my $name = $_; $params->{plugin}? ( $name eq $params->{plugin}  ) : 1 } @{ $sparrow->{plugins} } ) {
     my $plg_params =  $params || {};
-    delete @{$plg_params}{qw{plugin}};
-    my $plg_params_string;
+    delete @{$plg_params}{qw{plugin Misc:Sparrow:plugin_run}};
+    my $plg_params_string = '';
     for my $n (keys %{$plg_params}){
       $plg_params_string.=" --param $n=".($plg_params->{$n});
     }

--- a/Rex/Misc/Sparrow/files/sparrow.yml.example
+++ b/Rex/Misc/Sparrow/files/sparrow.yml.example
@@ -1,11 +1,6 @@
 sparrow:
-    system:
-        - checkname: disk
-          plugin: df-check
-          settings:
-              threshold: 80
-        - checkname: nginx
-          plugin: nginx-check
-          settings:
-              check_master_age: 0
-              master_age: 60
+  plugins:
+    - df-check
+    - nginx-check
+    - perlbrew
+


### PR DESCRIPTION
Hi Ferenc! I made a lot of updates to Rex::Misc::Sparrow module to simplify a rex/Sparrow usage/integration. Highlights:
- this version of Rex::Misc::Sparrow is fully compatible with the latest version of Sparrow ( current version of Rex::Misc::Sparrow  won't work with the latest version of Sparrow )
- **configure task** just installs Sparrow and dependencies 
- I decided not to manage  sparrow checkpoints via rex ( for the complexity reasons )
- Instead of  managing checkpoints Rex::Misc::Sparrow just installs a list of plugins with **setup task**
- A new **plugin_run task** runs an installed sparrow plugins in two favours:
  - a whole list 
  - a single plugin ( using --plugin=$name ) parameter

Optionally for  both  favours  one may set a runtime plugin parameters like:

`rex -qw Misc:Sparrow:plugin_run --plugin=df-check --threshold=88`
- sparrow.yml is very simple now and is just a list of sparrow plugins to install:

```
sparrow:
  plugins:
    - df-check
    - nginx-check
    - perlbrew
```
- details at  pod for Rex/Misc/Sparrow/**module**.pm  
- ~~**check** and **dump_config**~~ tasks are gone ( no need for them )
